### PR TITLE
fix: Add an OCaml version constraint

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -22,6 +22,6 @@
               on memory usage, allowing your application to prioritize improved
               run time when memory usage is low, but prioritize decreased memory
               usage when memory usage is high.")
- (depends ocaml)
+ (depends (ocaml (>= 4.08.0)))
  (tags
   ("garbage collector" "gc")))

--- a/dynamic_gc.opam
+++ b/dynamic_gc.opam
@@ -15,7 +15,7 @@ doc: "https://github.com/semgrep/dynamic-gc"
 bug-reports: "https://github.com/semgrep/dynamic-gc/issues"
 depends: [
   "dune" {>= "3.17"}
-  "ocaml"
+  "ocaml" {>= "4.08.0"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
CI in opam caught that `Float.round` was not available until OCaml 4.08. 